### PR TITLE
Test for successful completion

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -5,9 +5,19 @@
 
 while :
 do
-	DATE=`date`
-	/zap2xml.pl -u $USERNAME -p $PASSWORD -U -o /data/$XMLTV_FILENAME $OPT_ARGS
-	echo "Last run time: $DATE"
-	echo "Will run in $SLEEPTIME seconds"
-	sleep $SLEEPTIME
+  DATE=`date`
+  LASTRUN=$('date' +%s)
+  /zap2xml.pl -u $USERNAME -p $PASSWORD -U -o /data/$XMLTV_FILENAME $OPT_ARGS
+  LASTXMLMOD=$(date -r ./data/$XMLTV_FILENAME +%s)
+  if test $LASTXMLMOD -gt $LASTRUN
+  then
+      echo "Last run time: $DATE"
+      echo "Will run in $SLEEPTIME seconds"
+      sleep $SLEEPTIME
+  else
+      echo "Last run time: $DATE"
+      echo "Did not complete successfully"
+      echo "Pausing for 30 seconds and trying again"
+      sleep 30
+  fi
 done


### PR DESCRIPTION
It seems like zap2it has been rate limiting lately and jobs fail when they do. I added a simple test in entry.sh to determine if the job completed and saved to xml. If successful wait the sleeptime, if not try again.

Hope this helps someone out there. Solved my problem with failed jobs.