### PR TITLE
Add optional second user, then tv_merge the results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,24 @@ FROM alpine:3
 
 ENV USERNAME=none
 ENV PASSWORD=none
-ENV XMLTV_FILENAME=xmltv.xml
 ENV OPT_ARGS=
+
+ENV USERNAME2=none
+ENV PASSWORD2=none
+ENV OPT_ARGS2=
+
+ENV XMLTV_FILENAME=xmltv.xml
 
 # Wait 12 Hours after run
 ENV SLEEPTIME=43200
 
 RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN echo "@edgetesting http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk add --no-cache perl@edge perl-html-parser@edge perl-http-cookies@edge perl-lwp-useragent-determined@edge perl-json@edge perl-json-xs@edge
-RUN apk add --no-cache perl-lwp-protocol-https@edge perl-uri@edge ca-certificates@edge perl-net-libidn@edge perl-net-ssleay@edge perl-io-socket-ssl@edge perl-libwww@edge perl-mozilla-ca@edge perl-net-http@edge
+RUN apk add --no-cache perl@edge perl-html-parser@edge perl-http-cookies@edge \
+                       perl-lwp-useragent-determined@edge perl-json@edge perl-json-xs@edge \
+                       perl-lwp-protocol-https@edge perl-uri@edge ca-certificates@edge \
+                       perl-net-libidn@edge perl-net-ssleay@edge perl-io-socket-ssl@edge \
+                       perl-libwww@edge perl-mozilla-ca@edge perl-net-http@edge
+RUN apk add --no-cache xmltv@edge
 
 VOLUME /data
 ADD zap2xml.pl /zap2xml.pl

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # zap2xml
 Docker container for zap2xml
 
-This is zap2xml with Environment Variables driving the configuration. By default it runs every 12 hours to update your EPG data from zap2it
+This is zap2xml with Environment Variables driving the configuration. By default it runs every 12 hours to update your EPG data from zap2it. This container will take a second account for zap2it and will merge the received xml files into one using tv_merge.
 
 ## Quick Run
-`docker run -d --name zap2xml -v /xmltvdata:/data -e USERNAME=youremail@email.com -e PASSWORD=**password** -e OPT_ARGS="-I -D" -e XMLTV_FILENAME=xmltv.xml shuaiscott/zap2xml`
+`docker run -d --name zap2xml -v /xmltvdata:/data -e USERNAME=youremail@email.com -e PASSWORD=**password** -e OPT_ARGS="-I -D -a" -e USERNAME2=yourseconduser@email.com -e PASSWORD2=**secondpassword** -e OPT_ARGS2="-I -D" -e XMLTV_FILENAME=xmltv.xml sparticuz/zap2xml`
 
 ## Environment Settings
 You can configure the following environment variables below:
@@ -15,5 +15,8 @@ You can configure the following environment variables below:
 
 ### Optional
 - OPT_ARGS - additional command line arguments for zap2xml
+- USERNAME2 - Second zap2it.com username
+- PASSWORD2 - Second zap2it.com password
+- OPT_ARGS2 = additional command line arguments for zap2xml for the second username
 - XMLTV_FILENAME - filename for your xmltv file (default: xmltv.xml)
 - SLEEPTIME - time in seconds to wait before next run (default: 43200)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker container for zap2xml
 This is zap2xml with Environment Variables driving the configuration. By default it runs every 12 hours to update your EPG data from zap2it. This container will take a second account for zap2it and will merge the received xml files into one using tv_merge.
 
 ## Quick Run
-`docker run -d --name zap2xml -v /xmltvdata:/data -e USERNAME=youremail@email.com -e PASSWORD=**password** -e OPT_ARGS="-I -D -a" -e USERNAME2=yourseconduser@email.com -e PASSWORD2=**secondpassword** -e OPT_ARGS2="-I -D" -e XMLTV_FILENAME=xmltv.xml sparticuz/zap2xml`
+`docker run -d --name zap2xml -v /xmltvdata:/data -e USERNAME=youremail@email.com -e PASSWORD=**password** -e OPT_ARGS="-I -D -a" -e USERNAME2=yourseconduser@email.com -e PASSWORD2=**secondpassword** -e OPT_ARGS2="-I -D" -e XMLTV_FILENAME=xmltv.xml shuaiscott/zap2xml`
 
 ## Environment Settings
 You can configure the following environment variables below:

--- a/entry.sh
+++ b/entry.sh
@@ -6,7 +6,28 @@
 while :
 do
 	DATE=`date`
-	/zap2xml.pl -u $USERNAME -p $PASSWORD -U -o /data/$XMLTV_FILENAME $OPT_ARGS
+	mkdir -p /tmp/xmltv/raws
+	mkdir -p /tmp/xmltv/sorted
+
+	echo "Run zap2xml.pl"
+	/zap2xml.pl -u $USERNAME -p $PASSWORD -U -o /tmp/xmltv/raws/1.xml -c cache1 $OPT_ARGS
+
+	if [ $USERNAME2 = "none" ]
+	then
+		# Just move the raw file to the output
+		mv /tmp/xmltv/raws/1.xml /data/$XMLTV_FILENAME
+	else
+		# Run it again, sort, and merge the files
+		echo "Run zap2xml.pl for second user"
+		/zap2xml.pl -u ${USERNAME2} -p ${PASSWORD2} -U -o /tmp/xmltv/raws/2.xml -c cache2 $OPT_ARGS2
+		echo "Sorting both files"
+		tv_sort /tmp/xmltv/raws/1.xml --by-channel --output /tmp/xmltv/sorted/1.xml
+		tv_sort /tmp/xmltv/raws/2.xml --by-channel --output /tmp/xmltv/sorted/2.xml
+		echo "Merging both files"
+		tv_merge -i /tmp/xmltv/sorted/1.xml -m /tmp/xmltv/sorted/2.xml -o /data/$XMLTV_FILENAME
+	fi
+	echo "Removing intermediate files"
+	rm -rf /tmp/xmltv
 	echo "Last run time: $DATE"
 	echo "Will run in $SLEEPTIME seconds"
 	sleep $SLEEPTIME


### PR DESCRIPTION
This PR adds an optional second user, which, if filled out, will run zap2xml.pl a second time, retrieving the xml file for the second user. This will then be sorted using tv_sort, then merged using tv_merge, which outputs to XMLTV_FILENAME.

This is a non-breaking change. If USERNAME2 is not filled out, it will continue to work as is.

The only change to existing code was adding in `xmltv` from the Alpine repos.