### PR TITLE
fix: use orbebb instead of gapzap

### DIFF
--- a/zap2xml.pl
+++ b/zap2xml.pl
@@ -265,7 +265,7 @@ if (defined($options{z})) {
       my $zstart = substr($ms, 0, -3);
       $params = "?time=$zstart&timespan=$gridHours&pref=$zapPref&";
       $params .= &getZapGParams();
-      $params .= '&TMSID=&AffiliateID=gapzap&FromPage=TV%20Grid';
+      $params .= '&TMSID=&AffiliateID=orbebb&FromPage=TV%20Grid';
       $params .= '&ActivityID=1&OVDID=&isOverride=true';
       $rs = &getURL($urlRoot . "api/grid$params",1);
       last if ($rs eq '');
@@ -896,7 +896,7 @@ sub getZapParams {
   $phash{countryCode} = $country;
   $phash{headendId} = $lineupId;
   $phash{device} = $device;
-  $phash{aid} = 'gapzap';
+  $phash{aid} = 'orbebb';
   return %phash;
 }
 

--- a/zap2xml.pl
+++ b/zap2xml.pl
@@ -77,6 +77,7 @@ $device;
 $sleeptime = 0;
 $allChan = 0;
 $shiftMinutes = 0;
+$aid = 'orbebb';
 
 $outputXTVD = 0;
 $lineuptype;
@@ -265,7 +266,7 @@ if (defined($options{z})) {
       my $zstart = substr($ms, 0, -3);
       $params = "?time=$zstart&timespan=$gridHours&pref=$zapPref&";
       $params .= &getZapGParams();
-      $params .= '&TMSID=&AffiliateID=orbebb&FromPage=TV%20Grid';
+      $params .= "&TMSID=&AffiliateID=$aid&FromPage=TV%20Grid";
       $params .= '&ActivityID=1&OVDID=&isOverride=true';
       $rs = &getURL($urlRoot . "api/grid$params",1);
       last if ($rs eq '');
@@ -896,7 +897,7 @@ sub getZapParams {
   $phash{countryCode} = $country;
   $phash{headendId} = $lineupId;
   $phash{device} = $device;
-  $phash{aid} = 'orbebb';
+  $phash{aid} = $aid;
   return %phash;
 }
 


### PR DESCRIPTION
There was a change to the affiliate gracenote uses to fill tv listing information. Using `orbebb`  instead of `gapzap` seems to allow things to function as they use to. With `gapzap`, I faced incorrect zip code errors no matter which zip code I used.

This was tested by manually specifying the editing `zap2xml.pl` file in a docker compose volume entry:

```yaml
    volumes:
      - $DOCKER_CONFIG_DIR/xmltv:/data
      - ../../scripts/zap2xml.pl:/zap2xml.pl
``` 